### PR TITLE
Fix bug when image uses less than 6 subpalettes

### DIFF
--- a/eb_png2fts.py
+++ b/eb_png2fts.py
@@ -188,8 +188,11 @@ class EbTileset:
     def compute(self):
         # Use palettepacker library to perform better packing of
         # palettes into subpalettes
-        self.palette.subpalettes, subpalette_map = \
+        packedSubpalettes, subpalette_map = \
             palettepacker.tilePalettesToSubpalettes(self.tile_palettes)
+        assert(len(packedSubpalettes) <= 6)
+        # Keep the length of subpalettes the same
+        self.palette.subpalettes[:len(packedSubpalettes)] = packedSubpalettes
 
         for chunk_idx, tile_images in enumerate(self.chunk_tile_images):
             chunk_tiles = []


### PR DESCRIPTION
At the moment, when an image uses less than 6 subpalettes, it will be written into the .fts file with only the subpalettes which are used. This causes CoilSnake and EbProjEdit to fail to parse the .fts